### PR TITLE
Add the `#[topo::from_env(foo: Foo, ...)]` attribute macro

### DIFF
--- a/dom/examples/todo/src/filter.rs
+++ b/dom/examples/todo/src/filter.rs
@@ -38,19 +38,19 @@ impl Visibility {
 }
 
 #[topo::aware]
+#[topo::from_env(visibility: Key<Visibility>)]
 pub fn filter_link(to_set: Visibility) {
     tracing::info!({ id = ?topo::Id::current(), ?to_set }, "filter_link");
-    let visibility = topo::Env::expect::<Key<Visibility>>().clone();
 
     element!("li", |e| e.inner(|| {
         tracing::info!({ id = ?topo::Id::current() }, "inside li");
         element!("a", |link| {
             link.attr("style", "cursor: pointer;");
-            if *visibility == to_set {
+            if **visibility == to_set {
                 link.attr("class", "selected");
             }
 
-            link.on(move |_: ClickEvent, _| Some(to_set), visibility)
+            link.on(move |_: ClickEvent, _| Some(to_set), visibility.clone())
                 .inner(|| text!(to_set));
         });
     }));

--- a/dom/examples/todo/src/footer.rs
+++ b/dom/examples/todo/src/footer.rs
@@ -24,9 +24,8 @@ pub fn items_remaining(num_active: usize) {
 }
 
 #[topo::aware]
+#[topo::from_env(todos: Key<Vec<Todo>>)]
 pub fn clear_completed_button() {
-    let todos = topo::Env::expect::<Key<Vec<Todo>>>();
-
     element!("button", |e| e
         .attr("class", "clear-completed")
         .on(

--- a/dom/examples/todo/src/header.rs
+++ b/dom/examples/todo/src/header.rs
@@ -5,9 +5,9 @@ use {
 };
 
 #[topo::aware]
+#[topo::from_env(todos: Key<Vec<Todo>>)]
 pub fn header() {
-    let todos = topo::Env::expect::<Key<Vec<Todo>>>();
-
+    let todos = todos.clone();
     element!("header", |e| e.attr("class", "header").inner(|| {
         element!("h1", |e| e.inner(|| text!("todos")));
         text_input!("What needs to be done?", false, move |value: String| {

--- a/dom/examples/todo/src/item.rs
+++ b/dom/examples/todo/src/item.rs
@@ -4,9 +4,9 @@ use {
 };
 
 #[topo::aware]
+#[topo::from_env(todos: Key<Vec<Todo>>)]
 fn item_edit_input(todo: Todo, editing: Key<bool>) {
-    let todos = topo::Env::expect::<Key<Vec<Todo>>>();
-
+    let todos = todos.clone();
     text_input!(&todo.text.clone(), true, move |value: String| {
         editing.set(false);
         todos.update(|todos| {
@@ -20,8 +20,8 @@ fn item_edit_input(todo: Todo, editing: Key<bool>) {
 }
 
 #[topo::aware]
+#[topo::from_env(todos: Key<Vec<Todo>>)]
 fn item_with_buttons(todo: Todo, editing: Key<bool>) {
-    let todos = topo::Env::expect::<Key<Vec<Todo>>>();
     let id = todo.id;
 
     element!("div", |e| e.attr("class", "view").inner(|| {

--- a/dom/examples/todo/src/main_section.rs
+++ b/dom/examples/todo/src/main_section.rs
@@ -4,8 +4,8 @@ use {
 };
 
 #[topo::aware]
+#[topo::from_env(todos: Key<Vec<Todo>>)]
 pub fn toggle(default_checked: bool) {
-    let todos = topo::Env::expect::<Key<Vec<Todo>>>();
     element!("span", |e| e.inner(|| {
         element!("input", |e| {
             e.attr("class", "toggle-all")
@@ -33,9 +33,8 @@ pub fn toggle(default_checked: bool) {
 }
 
 #[topo::aware]
+#[topo::from_env(todos: Key<Vec<Todo>>, visibility: Key<Visibility>)]
 pub fn todo_list() {
-    let todos = topo::Env::expect::<Key<Vec<Todo>>>();
-    let visibility = topo::Env::expect::<Key<Visibility>>();
     element!("ul", |e| e.attr("class", "todo-list").inner(|| {
         for todo in todos.iter() {
             if visibility.should_show(todo) {
@@ -46,8 +45,8 @@ pub fn todo_list() {
 }
 
 #[topo::aware]
+#[topo::from_env(todos: Key<Vec<Todo>>)]
 pub fn main_section() {
-    let todos = topo::Env::expect::<Key<Vec<Todo>>>();
     let num_complete = todos.iter().filter(|t| t.completed).count();
 
     element!("section", |e| e.attr("class", "main").inner(move || {

--- a/dom/src/lib.rs
+++ b/dom/src/lib.rs
@@ -135,8 +135,8 @@ impl ArcWake for RuntimeWaker {
 }
 
 #[topo::aware]
+#[topo::from_env(parent: MemoElement)]
 pub fn text(s: impl ToString) {
-    let parent: &MemoElement = &*topo::Env::expect();
     // TODO consider a ToOwned-based memoization API that's lower level?
     // memo_ref<Ref, Arg, Output>(reference: Ref, init: impl FnOnce(Arg) -> Output)
     // where Ref: ToOwned<Owned=Arg> + PartialEq, etcetcetc
@@ -145,8 +145,8 @@ pub fn text(s: impl ToString) {
 }
 
 #[topo::aware]
+#[topo::from_env(parent: MemoElement)]
 pub fn element<ChildRet>(ty: &str, with_elem: impl FnOnce(&MemoElement) -> ChildRet) {
-    let parent: &MemoElement = &*topo::Env::expect();
     let elem = document().create_element(ty).unwrap();
     parent.ensure_child_attached(&elem);
     let elem = MemoElement {
@@ -185,7 +185,7 @@ impl MemoElement {
     {
         topo::call!(slot: Ev::NAME, {
             memo_with!(
-                *topo::Env::expect::<Revision>(),
+                Revision::current(),
                 |_| {
                     let target: &sys::EventTarget = self.elem.as_ref();
                     EventHandle::new(target.clone(), key, updater)

--- a/src/memo.rs
+++ b/src/memo.rs
@@ -11,6 +11,7 @@ use std::{
 ///
 /// Marks the memoized value as `Live` in the current `Revision`.
 #[topo::aware]
+#[topo::from_env(store: MemoStore)]
 pub fn memo_with<Arg, Stored, Ret>(
     arg: Arg,
     init: impl FnOnce(&Arg) -> Stored,
@@ -21,7 +22,6 @@ where
     Stored: 'static,
     Ret: 'static,
 {
-    let store = topo::Env::expect::<MemoStore>();
     let key = (
         topo::Id::current(),
         TypeId::of::<Arg>(),

--- a/topo/macro/Cargo.toml
+++ b/topo/macro/Cargo.toml
@@ -13,5 +13,5 @@ include = ["Cargo.toml", "src/**/*.rs"]
 proc-macro = true
 
 [dependencies]
-quote = "0.6"
-syn = { version = "0.15", features = ["full"] }
+quote = "1.0"
+syn = { version = "1.0", features = ["full"] }

--- a/topo/macro/src/lib.rs
+++ b/topo/macro/src/lib.rs
@@ -135,6 +135,10 @@ fn docs_fn_signature(input_fn: &syn::ItemFn) -> TokenStream2 {
 /// Defines required [topo::Env] values for a function. Binds the provided types as if references to
 /// them were implicit function arguments.
 ///
+/// TODO this should allow for binding optionally and non-optionally (panicking), and also
+/// allow the default of binding by reference and allow attempting to clone something to receive it
+/// by value
+///
 /// # Examples
 ///
 /// TODO

--- a/topo/src/lib.rs
+++ b/topo/src/lib.rs
@@ -51,7 +51,7 @@
 //! TODO show example of a rendering loop
 //!
 
-pub use topo_macro::aware;
+pub use topo_macro::{aware, from_env};
 
 use {
     owning_ref::OwningRef,


### PR DESCRIPTION
Allows writing environment references as if they were function arguments.