### PR TITLE
[dom] Expose regular callbacks & offer raw element node access

### DIFF
--- a/dom/examples/hacking/src/lib.rs
+++ b/dom/examples/hacking/src/lib.rs
@@ -14,7 +14,7 @@ pub fn main() {
 
         element!("button", |e| e
             .attr("type", "button")
-            .on(|_: ClickEvent, count| Some(count + 1), count)
+            .on(move |_: ClickEvent| count.update(|c| Some(c + 1)))
             .inner(|| text!("increment")));
 
         vec![text!("first"), text!(" second"), text!(" third")];

--- a/dom/examples/todo/src/filter.rs
+++ b/dom/examples/todo/src/filter.rs
@@ -40,17 +40,16 @@ impl Visibility {
 #[topo::aware]
 #[topo::from_env(visibility: Key<Visibility>)]
 pub fn filter_link(to_set: Visibility) {
-    tracing::info!({ id = ?topo::Id::current(), ?to_set }, "filter_link");
+    let visibility = visibility.clone();
 
     element!("li", |e| e.inner(|| {
-        tracing::info!({ id = ?topo::Id::current() }, "inside li");
         element!("a", |link| {
             link.attr("style", "cursor: pointer;");
-            if **visibility == to_set {
+            if *visibility == to_set {
                 link.attr("class", "selected");
             }
 
-            link.on(move |_: ClickEvent, _| Some(to_set), visibility.clone())
+            link.on(move |_: ClickEvent| visibility.set(to_set))
                 .inner(|| text!(to_set));
         });
     }));

--- a/dom/examples/todo/src/footer.rs
+++ b/dom/examples/todo/src/footer.rs
@@ -26,12 +26,11 @@ pub fn items_remaining(num_active: usize) {
 #[topo::aware]
 #[topo::from_env(todos: Key<Vec<Todo>>)]
 pub fn clear_completed_button() {
+    let todos = todos.clone();
     element!("button", |e| e
         .attr("class", "clear-completed")
-        .on(
-            |_: ClickEvent, todos| Some(todos.iter().filter(|t| !t.completed).cloned().collect()),
-            todos.clone(),
-        )
+        .on(move |_: ClickEvent| todos
+            .update(|t| Some(t.iter().filter(|t| !t.completed).cloned().collect())),)
         .inner(|| text!("Clear completed")));
 }
 

--- a/dom/examples/todo/src/input.rs
+++ b/dom/examples/todo/src/input.rs
@@ -20,30 +20,24 @@ pub fn text_input(placeholder: &str, editing: bool, mut on_save: impl FnMut(Stri
         val
     }
 
+    let change_text = text.clone();
+
     element!("input", |e| {
         e.attr("autoFocus", "true")
             .attr("class", "new-todo")
             .attr("placeholder", placeholder)
             .attr("type", "text")
             .attr("value", &*text)
-            .on(
-                |change: ChangeEvent, _| Some(input_value(change)),
-                text.clone(),
-            )
-            .on(
-                move |keypress: KeyDownEvent, _| {
-                    if keypress.key() == "Enter" {
-                        let value = input_value(keypress);
-                        if !value.is_empty() {
-                            on_save(value);
-                        }
-                        Some("".into())
-                    } else {
-                        None
+            .on(move |change: ChangeEvent| change_text.set(input_value(change)))
+            .on(move |keypress: KeyDownEvent| {
+                if keypress.key() == "Enter" {
+                    let value = input_value(keypress);
+                    if !value.is_empty() {
+                        on_save(value);
                     }
-                },
-                text,
-            );
+                    text.set("".into());
+                }
+            });
 
         if editing {
             e.attr("class", "edit");

--- a/dom/examples/todo/src/main_section.rs
+++ b/dom/examples/todo/src/main_section.rs
@@ -6,6 +6,7 @@ use {
 #[topo::aware]
 #[topo::from_env(todos: Key<Vec<Todo>>)]
 pub fn toggle(default_checked: bool) {
+    let todos = todos.clone();
     element!("span", |e| e.inner(|| {
         element!("input", |e| {
             e.attr("class", "toggle-all")
@@ -14,20 +15,20 @@ pub fn toggle(default_checked: bool) {
         });
 
         element!("label", |e| {
-            e.on(
-                move |_: ClickEvent, todos| -> Option<Vec<Todo>> {
-                    todos
-                        .iter()
-                        .map(|t| {
-                            let mut new = t.clone();
-                            new.completed = !default_checked;
-                            new
-                        })
-                        .collect::<Vec<_>>()
-                        .into()
-                },
-                todos.clone(),
-            );
+            e.on(move |_: ClickEvent| {
+                todos.update(|t| {
+                    Some(
+                        t.iter()
+                            .map(|t| {
+                                let mut new = t.clone();
+                                new.completed = !default_checked;
+                                new
+                            })
+                            .collect::<Vec<_>>()
+                            .into(),
+                    )
+                })
+            });
         });
     }));
 }

--- a/dom/src/lib.rs
+++ b/dom/src/lib.rs
@@ -84,6 +84,15 @@ impl MemoElement {
         }
     }
 
+    /// Retrieves access to the raw HTML element underlying the `MemoElement`.
+    ///
+    /// Because this offers an escape hatch around the memoized mutations, it should be used with
+    /// caution. Also because of this, it has a silly name intended to loudly announce that
+    /// care must be taken.
+    pub fn raw_element_that_has_sharp_edges_please_be_careful(&self) -> sys::Element {
+        self.elem.clone()
+    }
+
     // FIXME this should be topo-aware
     // TODO and it should be able to express its slot as an annotation
     pub fn attr(&self, name: &'static str, value: impl ToString) -> &Self {


### PR DESCRIPTION
To more closely match the mutable model of the DOM, `MemoElement::on` doesn't require a state pointer, as you may need to perform manually-tracked mutations on the underlying node. To make this possible we also expose a new method on `MemoElement` for quasi-safely getting the actual DOM node.

related to https://github.com/anp/moxie/issues/50