### PR TITLE
Second 'on' handler ignored

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: push
+on: [pull_request, push]
 
 jobs:
   main:

--- a/dom/examples/drivertest/Cargo.toml
+++ b/dom/examples/drivertest/Cargo.toml
@@ -17,4 +17,5 @@ version = "0.3.28"
 features = [
     "Element",
     "Node",
+    "HtmlElement",
 ]

--- a/dom/examples/drivertest/src/lib.rs
+++ b/dom/examples/drivertest/src/lib.rs
@@ -1,6 +1,6 @@
 use {
     moxie_dom::{
-        elements::{li, ul, button},
+        elements::{button, li, ul},
         embed::WebRuntime,
         prelude::*,
     },
@@ -94,7 +94,7 @@ fn mutiple_event_listeners() {
         let counter1 = moxie::state::state(|| 0u8);
         let counter2 = moxie::state::state(|| 0u8);
 
-        let increment = |n: &u8| { Some(n + 1) };
+        let increment = |n: &u8| Some(n + 1);
 
         // Clone the counters so they can be displayed later
         let (counter1_val, counter2_val) = (counter1.clone(), counter2.clone());
@@ -119,14 +119,21 @@ fn mutiple_event_listeners() {
         .and_then(|node| node.dyn_into::<sys::HtmlElement>().ok())
         .unwrap();
 
-    assert_eq!(button_element.inner_text(), "counter1 = 0, counter2 = 0", "Counters should start at zero");
+    assert_eq!(
+        button_element.inner_text(),
+        "counter1 = 0, counter2 = 0",
+        "Counters should start at zero"
+    );
 
     button_element.click(); // Simulate a click event
     web_tester.run_once(); // Update the DOM
 
-    assert_eq!(button_element.inner_text(), "counter1 = 1, counter2 = 1", "Counters should be updated once");
+    assert_eq!(
+        button_element.inner_text(),
+        "counter1 = 1, counter2 = 1",
+        "Counters should be updated once"
+    );
 }
-
 
 fn assert_vnode_matches_element(expected: &VNode<String>, actual: &sys::Node) {
     match (expected, actual.node_type()) {

--- a/dom/src/lib.rs
+++ b/dom/src/lib.rs
@@ -159,7 +159,6 @@ impl MemoElement {
         self
     }
 
-    // FIXME this should be topo-nested
     /// Declare an event handler on the element.
     ///
     /// A guard value is stored as a resulting "effect" of the mutation, and removes the attribute
@@ -168,6 +167,7 @@ impl MemoElement {
     ///
     /// Currently this is performed on every Revision, as changes to event handlers don't typically
     /// affect the debugging experience and have not yet shown up in performance profiles.
+    #[topo::nested]
     pub fn on<Ev>(&self, callback: impl FnMut(Ev) + 'static) -> &Self
     where
         Ev: 'static + Event,


### PR DESCRIPTION
Hello,

This is my attempt to fix issue #48.

- I fixed the issue by adding the `#[topo::nested]` attribute on the method `MemoElement::on()`. 
  I initially tried to use the `TypeId` of the callback, as suggested by @anp in https://github.com/anp/moxie/issues/48#issuecomment-535527040_, but it didn't work, probably because two callback share the same TypeId if the have the same type.
- I added a new test case for this issue. I didn't know were to add it, so I put it in the `drivertest` crate, because there was already a test there. Please let me know if it isn't the right place, I'll update it.