### PR TITLE
[core] embed::Runtime accepts an argument to its root closure.

### DIFF
--- a/benches/core.rs
+++ b/benches/core.rs
@@ -12,21 +12,21 @@ criterion::criterion_group!(runtime, once_from_store, run_empty, run_repeated);
 criterion::criterion_main!(runtime);
 
 fn once_from_store(c: &mut Criterion) {
-    let mut rt = Runtime::new(|| once(|| Rc::new(vec![0; 1_000_000])));
-    rt.run_once();
-    c.bench_function("1mb vec cached", |b| b.iter(|| rt.run_once()));
+    let mut rt = Runtime::new(|()| once(|| Rc::new(vec![0; 1_000_000])));
+    rt.run_once(());
+    c.bench_function("1mb vec cached", |b| b.iter(|| rt.run_once(())));
 }
 
 fn run_empty(c: &mut Criterion) {
-    let mut rt = Runtime::new(|| Revision::current());
-    c.bench_function("run_empty", |b| b.iter(|| rt.run_once()));
+    let mut rt = Runtime::new(|()| Revision::current());
+    c.bench_function("run_empty", |b| b.iter(|| rt.run_once(())));
 }
 
 fn run_n_times_empty(b: &mut criterion::Bencher, n: &usize) {
-    let mut rt = Runtime::new(|| Revision::current());
+    let mut rt = Runtime::new(|()| Revision::current());
     b.iter(|| {
         for _ in 0..*n {
-            rt.run_once();
+            rt.run_once(());
         }
     });
 }

--- a/src/load.rs
+++ b/src/load.rs
@@ -98,7 +98,7 @@ mod tests {
         // this is uh weird, but we know up front how much we'll poll this
         let recv = Rc::new(futures::lock::Mutex::new(Some(recv)));
 
-        let mut rt = crate::embed::Runtime::new(move || -> Poll<u8> {
+        let mut rt = crate::embed::Runtime::new(move |()| -> Poll<u8> {
             let recv = recv.clone();
             load_once(|| async move {
                 recv.lock()
@@ -110,13 +110,13 @@ mod tests {
             })
         });
 
-        assert_eq!(rt.run_once(), Poll::Pending, "no values received when nothing sent");
-        assert_eq!(rt.run_once(), Poll::Pending, "no values received, and we aren't blocking");
+        assert_eq!(rt.run_once(()), Poll::Pending, "no values received when nothing sent");
+        assert_eq!(rt.run_once(()), Poll::Pending, "no values received, and we aren't blocking");
 
         send.send(5u8).unwrap();
-        assert_eq!(rt.run_once(), Poll::Ready(5), "we need to receive the value we sent");
+        assert_eq!(rt.run_once(()), Poll::Ready(5), "we need to receive the value we sent");
         assert_eq!(
-            rt.run_once(),
+            rt.run_once(()),
             Poll::Ready(5),
             "the value we sent must be cached because its from a oneshot channel"
         );
@@ -127,7 +127,7 @@ mod tests {
         let (send, recv) = futures::channel::oneshot::channel();
         let recv = Rc::new(futures::lock::Mutex::new(Some(recv)));
 
-        let mut rt = crate::embed::Runtime::new(move || -> Option<Poll<u8>> {
+        let mut rt = crate::embed::Runtime::new(move |()| -> Option<Poll<u8>> {
             if crate::embed::Revision::current().0 < 3 {
                 let recv = recv.clone();
                 Some(load_once(|| async move {
@@ -143,16 +143,16 @@ mod tests {
             }
         });
 
-        assert_eq!(rt.run_once(), Some(Poll::Pending));
+        assert_eq!(rt.run_once(()), Some(Poll::Pending));
         assert!(!send.is_canceled(), "interest expressed, receiver must be live");
 
-        assert_eq!(rt.run_once(), Some(Poll::Pending));
+        assert_eq!(rt.run_once(()), Some(Poll::Pending));
         assert!(!send.is_canceled(), "interest still expressed, receiver must be live");
 
-        assert_eq!(rt.run_once(), None);
+        assert_eq!(rt.run_once(()), None);
         assert!(!send.is_canceled(), "interest dropped, task live for another revision");
 
-        assert_eq!(rt.run_once(), None);
+        assert_eq!(rt.run_once(()), None);
         assert!(send.is_canceled(), "interest dropped, task dropped");
 
         assert!(

--- a/src/memo.rs
+++ b/src/memo.rs
@@ -189,7 +189,7 @@ mod tests {
 
             let mut prev_revision = None;
             let mut comp_skipped_count = 0;
-            let mut rt = Runtime::new(|| {
+            let mut rt = Runtime::new(|()| {
                 let revision = Revision::current();
 
                 if let Some(pr) = prev_revision {
@@ -213,7 +213,7 @@ mod tests {
             for i in 0..5 {
                 assert_eq!(rt.revision().0, i);
 
-                rt.run_once();
+                rt.run_once(());
 
                 assert_eq!(rt.revision().0, i + 1);
             }
@@ -230,14 +230,14 @@ mod tests {
             }
             assert_eq!(ids.len(), 10);
 
-            let mut rt = Runtime::new(|| {
+            let mut rt = Runtime::new(|()| {
                 let mut ids = HashSet::new();
                 for i in 0..10 {
                     memo(i, |_| ids.insert(topo::Id::current()));
                 }
                 assert_eq!(ids.len(), 10);
             });
-            rt.run_once();
+            rt.run_once(());
         });
     }
 
@@ -245,7 +245,7 @@ mod tests {
     fn memo_in_a_loop() {
         with_test_logs(|| {
             let num_iters = 10;
-            let mut rt = Runtime::new(|| {
+            let mut rt = Runtime::new(|()| {
                 let mut counts = vec![];
                 for i in 0..num_iters {
                     topo::call(|| once(|| counts.push(i)));
@@ -253,10 +253,10 @@ mod tests {
                 counts
             });
 
-            let first_counts = rt.run_once();
+            let first_counts = rt.run_once(());
             assert_eq!(first_counts.len(), num_iters, "each mutation must be called exactly once");
 
-            let second_counts = rt.run_once();
+            let second_counts = rt.run_once(());
             assert_eq!(
                 second_counts.len(),
                 0,
@@ -271,7 +271,7 @@ mod tests {
             let loop_ct = Cell::new(0);
             let raw_exec = Cell::new(0);
             let memo_exec = Cell::new(0);
-            let mut rt = Runtime::new(|| {
+            let mut rt = Runtime::new(|()| {
                 raw_exec.set(raw_exec.get() + 1);
                 memo(loop_ct.get(), |_| {
                     memo_exec.set(memo_exec.get() + 1);
@@ -293,8 +293,8 @@ mod tests {
                     "runtime's root block should run exactly twice per loop_ct value"
                 );
 
-                rt.run_once();
-                rt.run_once();
+                rt.run_once(());
+                rt.run_once(());
             }
         })
     }


### PR DESCRIPTION
This makes direct integration slightly more cumbersome but that's not a primary use case.

Closes #90.

cc @tiffany352, would be great to have your review on this.