### PR TITLE
parking_lot -> simple_mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ dyn-cache = { path = "dyn-cache", version = "0.12.0"}
 futures = "0.3.5"
 illicit = { path = "illicit", version = "1.1.1"}
 moxie-macros = { path = "macros", version = "0.1.0-pre" }
-parking_lot = "0.11"
+simple-mutex = "1.1.5"
 scopeguard = "1"
 topo = { path = "topo", version = "0.13.0"}
 tracing = "^0.1"

--- a/dyn-cache/Cargo.toml
+++ b/dyn-cache/Cargo.toml
@@ -18,7 +18,7 @@ downcast-rs = "1.1.1"
 hash_hasher = "2.0.3"
 hashbrown = "0.9.0"
 illicit = { path = "../illicit", version = "1.1.1"}
-parking_lot = "0.11.0"
+simple-mutex = "1.1.5"
 paste = "1.0.0"
 
 [dev-dependencies]

--- a/dyn-cache/src/definition.rs
+++ b/dyn-cache/src/definition.rs
@@ -379,7 +379,7 @@ impl std::panic::RefUnwindSafe for $shared {}
 mod $test_mod {
     use super::*;
     use std::sync::Arc;
-    use parking_lot::Mutex;
+    use simple_mutex::Mutex;
 
     #[test]
     fn single_query_with_gc() {

--- a/dyn-cache/src/dep_node.rs
+++ b/dyn-cache/src/dep_node.rs
@@ -1,6 +1,6 @@
 use super::Liveness;
 use illicit::AsContext;
-use parking_lot::Mutex;
+use simple_mutex::Mutex;
 use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},

--- a/dyn-cache/src/lib.rs
+++ b/dyn-cache/src/lib.rs
@@ -423,7 +423,7 @@ pub mod local {
 
 /// A thread-safe cache which requires stored types implement `Send`.
 pub mod sync {
-    use parking_lot::Mutex;
+    use simple_mutex::Mutex;
     use std::sync::Arc;
 
     define_cache!(sync, SendCache: Send, Arc, Mutex::lock);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub mod runtime;
 pub mod testing;
 
 use crate::runtime::{Context, Var};
-use parking_lot::Mutex;
+use simple_mutex::Mutex;
 use std::{
     borrow::Borrow,
     fmt::{Debug, Display, Formatter, Result as FmtResult},

--- a/src/runtime/var.rs
+++ b/src/runtime/var.rs
@@ -1,5 +1,5 @@
 use crate::{Commit, Key};
-use parking_lot::Mutex;
+use simple_mutex::Mutex;
 use std::{sync::Arc, task::Waker};
 
 /// The underlying container of state variables. Vends copies of the latest

--- a/topo/Cargo.toml
+++ b/topo/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 dyn-cache = { path = "../dyn-cache", version = "0.12.0"}
 illicit = { path = "../illicit", version = "1.1.1"}
 once_cell = "1.4.0"
-parking_lot = "0.11.0"
+simple-mutex = "1.1.5"
 topo-macro = { path = "macro", version = "0.10.0"}
 
 [dev-dependencies]

--- a/topo/src/slot.rs
+++ b/topo/src/slot.rs
@@ -1,6 +1,6 @@
 use dyn_cache::sync::SendCache;
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
+use simple_mutex::Mutex;
 use std::{
     any::{type_name, TypeId},
     borrow::Borrow,


### PR DESCRIPTION
Resolves #218 

This PR replaces the dependency [parking_lot](https://crates.io/crates/parking_lot) with [simple_mutex](https://crates.io/crates/simple-mutex) to resolve runtime bugs caused by `parking_lot`'s `Mutex::lock` in Wasm. See the [linked issue](https://github.com/anp/moxie/issues/218) for more info.

The fix has been manually tested through a Seed app that uses `topo` as an indirect dependency.

---

The PR has been marked as `Draft` because of two reasons:
1. I can't compile it because of the error below. The error was already present in the `main` branch without my changes:
```
$ cargo build --all
   Compiling counter-moxie-dom-struct v0.1.0 (D:\repos\moxie\dom\examples\counter_struct)
error: expected an identifier
  --> dom\examples\counter_struct\src\lib.rs:37:1
   |
37 | moxie_dom::app_boot!(Counter);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```
How should I resolve it?

2. It looks like the only thing that prevents to compile the project (at least `topo`) on the stable Rust is this line in `Cargo.toml`:
```toml
cargo-features = ["named-profiles"] # for coverage
```
Is there a simple way to remove this limitation?

Thank you!