### PR TITLE
Add web features to the `parking_lot` dependency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -77,8 +77,8 @@ watch --clear
     -x clippy-dom
 """
 
-wa-pack = "run --release --manifest-path dom/local-wasm-pack/Cargo.toml --"
-wa-pack-build = "wa-pack build --dev --target web --out-name index"
+wa-pack = "run --manifest-path dom/local-wasm-pack/Cargo.toml --"
+wa-pack-build = "wa-pack build --target web --out-name index"
 wa-test = "wa-pack test --chrome --headless"
 
 build-dom-lib = "wa-pack-build dom"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -77,8 +77,8 @@ watch --clear
     -x clippy-dom
 """
 
-wa-pack = "run --manifest-path dom/local-wasm-pack/Cargo.toml --"
-wa-pack-build = "wa-pack build --target web --out-name index"
+wa-pack = "run --release --manifest-path dom/local-wasm-pack/Cargo.toml --"
+wa-pack-build = "wa-pack build --dev --target web --out-name index"
 wa-test = "wa-pack test --chrome --headless"
 
 build-dom-lib = "wa-pack-build dom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ dyn-cache = { path = "dyn-cache", version = "0.12.0"}
 futures = "0.3.5"
 illicit = { path = "illicit", version = "1.1.1"}
 moxie-macros = { path = "macros", version = "0.1.0-pre" }
-parking_lot = "0.11"
+parking_lot = { version = "0.11", features = ["wasm-bindgen"]}
 scopeguard = "1"
 topo = { path = "topo", version = "0.13.0"}
 tracing = "^0.1"

--- a/dyn-cache/Cargo.toml
+++ b/dyn-cache/Cargo.toml
@@ -18,7 +18,7 @@ downcast-rs = "1.1.1"
 hash_hasher = "2.0.3"
 hashbrown = "0.9.0"
 illicit = { path = "../illicit", version = "1.1.1"}
-parking_lot = "0.11.0"
+parking_lot = { version = "0.11.0", features = ["wasm-bindgen"]}
 paste = "1.0.0"
 
 [dev-dependencies]

--- a/topo/Cargo.toml
+++ b/topo/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 dyn-cache = { path = "../dyn-cache", version = "0.12.0"}
 illicit = { path = "../illicit", version = "1.1.1"}
 once_cell = "1.4.0"
-parking_lot = "0.11.0"
+parking_lot = { version = "0.11.0", features = ["wasm-bindgen"]}
 topo-macro = { path = "macro", version = "0.10.0"}
 
 [dev-dependencies]


### PR DESCRIPTION
Resolves #218.

The `parking_lot` for wasm32 on stable Rust will panic on attempt of parking thread. This makes it possible to rely on stable version of `parking_lot` either with or without the `atomics` wasm32 target feature present. Therefore it is a step towards the stable toolchain (#221). Then the last step would be to disable (maybe conditionally) the `named-profiles` cargo feature.

While similar PR #219 conflicts with #223, this PR won't.