### PR TITLE
Reimplement `mox` with syn_rsx

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,6 +28,7 @@ clippy-core = """clippy
 --package illicit
 --package illicit-macro
 --package mox
+--package mox-impl
 --package moxie
 --package topo
 --package topo-macro
@@ -37,6 +38,7 @@ test-core = """test --all-targets
 --package illicit
 --package illicit-macro
 --package mox
+--package mox-impl
 --package moxie
 --package topo
 --package topo-macro
@@ -46,6 +48,7 @@ test-core-doc = """test --doc
 --package illicit
 --package illicit-macro
 --package mox
+--package mox-impl
 --package moxie
 --package topo
 --package topo-macro

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "rust-analyzer.cargo.loadOutDirsFromCheck": true,
-    "rust-analyzer.procMacro.enable": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.cargo.loadOutDirsFromCheck": true,
+    "rust-analyzer.procMacro.enable": true
+}

--- a/dom/Cargo.toml
+++ b/dom/Cargo.toml
@@ -47,6 +47,6 @@ wasm-bindgen = { version = "0.2.68", optional = true }
 wasm-bindgen-futures = { version = "0.4.13", optional = true }
 
 [dev-dependencies]
-mox = { path = "../mox", version = "0.10.0-pre"}
+mox = { path = "../mox", version = "0.11.0"}
 pretty_assertions = "0.6"
 wasm-bindgen-test = "0.3"

--- a/dom/examples/counter_fn/src/lib.rs
+++ b/dom/examples/counter_fn/src/lib.rs
@@ -9,9 +9,9 @@ pub fn boot(root: moxie_dom::raw::sys::Node) {
         let decrementer = incrementer.clone();
         mox! {
             <div>
-                <button onclick={move |_| decrementer.mutate(|count| *count -= 1)}>"-"</button>
+                <button onclick = move |_| decrementer.mutate(|count| *count -= 1)>"-"</button>
                 { count }
-                <button onclick={move |_| incrementer.mutate(|count| *count += 1)}>"+"</button>
+                <button onclick = move |_| incrementer.mutate(|count| *count += 1)>"+"</button>
             </div>
         }
     });

--- a/dom/examples/counter_fn/src/lib.rs
+++ b/dom/examples/counter_fn/src/lib.rs
@@ -10,7 +10,7 @@ pub fn boot(root: moxie_dom::raw::sys::Node) {
         mox! {
             <div>
                 <button onclick={move |_| decrementer.mutate(|count| *count -= 1)}>"-"</button>
-                {% "{}", count }
+                { count }
                 <button onclick={move |_| incrementer.mutate(|count| *count += 1)}>"+"</button>
             </div>
         }

--- a/dom/examples/counter_struct/src/lib.rs
+++ b/dom/examples/counter_struct/src/lib.rs
@@ -26,9 +26,9 @@ impl Stateful for Counter {
         let updater2 = updater.clone();
         mox! {
             <div>
-                <button onclick={move |_| updater.decrement()}>"-"</button>
+                <button onclick = move |_| updater.decrement()>"-"</button>
                 { self.0 }
-                <button onclick={move |_| updater2.increment()}>"+"</button>
+                <button onclick = move |_| updater2.increment()>"+"</button>
             </div>
         }
     }

--- a/dom/examples/counter_struct/src/lib.rs
+++ b/dom/examples/counter_struct/src/lib.rs
@@ -27,7 +27,7 @@ impl Stateful for Counter {
         mox! {
             <div>
                 <button onclick={move |_| updater.decrement()}>"-"</button>
-                {% "{}", self.0 }
+                { self.0 }
                 <button onclick={move |_| updater2.increment()}>"+"</button>
             </div>
         }

--- a/dom/examples/drivertest/src/lib.rs
+++ b/dom/examples/drivertest/src/lib.rs
@@ -78,8 +78,8 @@ fn mutiple_event_listeners() {
 
         mox! {
             <button
-                onclick={ move |_| counter1.update(increment) }
-                onclick={ move |_| counter2.update(increment) }
+                onclick = move |_| counter1.update(increment)
+                onclick = move |_| counter2.update(increment)
             >
                 // Display the values of the counters
                 {format_args!("counter1 = {}, counter2 = {}", &counter1_val, &counter2_val)}

--- a/dom/examples/drivertest/src/lib.rs
+++ b/dom/examples/drivertest/src/lib.rs
@@ -82,7 +82,7 @@ fn mutiple_event_listeners() {
                 onclick = move |_| counter2.update(increment)
             >
                 // Display the values of the counters
-                {format_args!("counter1 = {}, counter2 = {}", &counter1_val, &counter2_val)}
+                {% "counter1 = {}, counter2 = {}", &counter1_val, &counter2_val }
             </button>
         }
     });

--- a/dom/examples/drivertest/src/lib.rs
+++ b/dom/examples/drivertest/src/lib.rs
@@ -82,7 +82,7 @@ fn mutiple_event_listeners() {
                 onclick={ move |_| counter2.update(increment) }
             >
                 // Display the values of the counters
-                {% "counter1 = {}, counter2 = {}", &counter1_val, &counter2_val }
+                {format_args!("counter1 = {}, counter2 = {}", &counter1_val, &counter2_val)}
             </button>
         }
     });

--- a/dom/examples/hacking/src/lib.rs
+++ b/dom/examples/hacking/src/lib.rs
@@ -25,7 +25,7 @@ fn root() -> Div {
 
     let mut root = div();
 
-    root = root.child(mox! { <div>{% "hello world from moxie! ({})", &count }</div> });
+    root = root.child(mox! { <div>{format_args!("hello world from moxie! ({})", &count)}</div> });
     root = root.child(mox! {
         <button type="button" onclick={move |_| set_count.update(|c| Some(c + 1))}>
             "increment"
@@ -33,7 +33,7 @@ fn root() -> Div {
     });
 
     for t in &["first", "second", "third"] {
-        root = root.child(mox! { <div>{% "{}", t }</div> });
+        root = root.child(mox! { <div>{ t }</div> });
     }
 
     root.build()

--- a/dom/examples/hacking/src/lib.rs
+++ b/dom/examples/hacking/src/lib.rs
@@ -25,7 +25,7 @@ fn root() -> Div {
 
     let mut root = div();
 
-    root = root.child(mox! { <div>{format_args!("hello world from moxie! ({})", &count)}</div> });
+    root = root.child(mox! { <div>{% "hello world from moxie! ({})", &count }</div> });
     root = root.child(mox! {
         <button type="button" onclick = move |_| set_count.update(|c| Some(c + 1))>
             "increment"

--- a/dom/examples/hacking/src/lib.rs
+++ b/dom/examples/hacking/src/lib.rs
@@ -27,7 +27,7 @@ fn root() -> Div {
 
     root = root.child(mox! { <div>{format_args!("hello world from moxie! ({})", &count)}</div> });
     root = root.child(mox! {
-        <button type="button" onclick={move |_| set_count.update(|c| Some(c + 1))}>
+        <button type="button" onclick = move |_| set_count.update(|c| Some(c + 1))>
             "increment"
         </button>
     });

--- a/dom/examples/ssr/src/main.rs
+++ b/dom/examples/ssr/src/main.rs
@@ -31,7 +31,7 @@ struct PathExtractor {
 fn simple_list(items: &[String]) -> Ul {
     let mut list = ul();
     for item in items {
-        list = list.child(mox!(<li>{% "{}", item }</li>));
+        list = list.child(mox!(<li>{ item }</li>));
     }
     list.build()
 }

--- a/dom/examples/todo/src/filter.rs
+++ b/dom/examples/todo/src/filter.rs
@@ -49,8 +49,8 @@ pub fn filter_link(to_set: Visibility) -> Li {
     mox! {
         <li>
             <a style="cursor: pointer;"
-             class={if *visibility == to_set { "selected" } else { "" }}
-             onclick={move |_| visibility.set(to_set)}>
+             class = if *visibility == to_set { "selected" } else { "" }
+             onclick = move |_| visibility.set(to_set)>
                 { to_set }
             </a>
         </li>

--- a/dom/examples/todo/src/filter.rs
+++ b/dom/examples/todo/src/filter.rs
@@ -51,7 +51,7 @@ pub fn filter_link(to_set: Visibility) -> Li {
             <a style="cursor: pointer;"
              class={if *visibility == to_set { "selected" } else { "" }}
              onclick={move |_| visibility.set(to_set)}>
-                {% "{}", to_set }
+                { to_set }
             </a>
         </li>
     }

--- a/dom/examples/todo/src/footer.rs
+++ b/dom/examples/todo/src/footer.rs
@@ -11,7 +11,7 @@ pub fn items_remaining(num_active: usize) -> Span {
     mox! {
         <span class="todo-count">
             <strong>{bolded}</strong>
-            {format_args!(" {} left", if num_active == 1 { "item" } else { "items" })}
+            {% " {} left", if num_active == 1 { "item" } else { "items" } }
         </span>
     }
 }

--- a/dom/examples/todo/src/footer.rs
+++ b/dom/examples/todo/src/footer.rs
@@ -11,7 +11,7 @@ pub fn items_remaining(num_active: usize) -> Span {
     mox! {
         <span class="todo-count">
             <strong>{bolded}</strong>
-            {% " {} left", if num_active == 1 { "item" } else { "items" } }
+            {format_args!(" {} left", if num_active == 1 { "item" } else { "items" })}
         </span>
     }
 }

--- a/dom/examples/todo/src/footer.rs
+++ b/dom/examples/todo/src/footer.rs
@@ -23,7 +23,7 @@ pub fn clear_completed_button(num_complete: usize) -> Button {
     let remove_completed =
         move |_| todos.update(|t| Some(t.iter().filter(|t| !t.completed).cloned().collect()));
     mox! {
-        <button class="clear-completed" disabled={num_complete == 0} onclick={remove_completed}>
+        <button class="clear-completed" disabled=num_complete==0 onclick=remove_completed>
             "Clear completed"
         </button>
     }

--- a/dom/examples/todo/src/footer.rs
+++ b/dom/examples/todo/src/footer.rs
@@ -23,7 +23,9 @@ pub fn clear_completed_button(num_complete: usize) -> Button {
     let remove_completed =
         move |_| todos.update(|t| Some(t.iter().filter(|t| !t.completed).cloned().collect()));
     mox! {
-        <button class="clear-completed" disabled=num_complete==0 onclick=remove_completed>
+        <button class="clear-completed"
+            disabled = num_complete == 0
+            onclick = remove_completed>
             "Clear completed"
         </button>
     }

--- a/dom/examples/todo/src/input.rs
+++ b/dom/examples/todo/src/input.rs
@@ -24,10 +24,10 @@ pub fn text_input(
     }
 
     mox! {
-        <input type="text" placeholder={placeholder} value={&text} autofocus={true}
-            class={if editing { "edit new-todo" } else { "new-todo"}}
-            onchange={move |change| set_text.set(input_value(change))}
-            onkeydown={move |keypress| {
+        <input type="text" placeholder value=&text autofocus=true
+            class = if editing { "edit new-todo" } else { "new-todo" }
+            onchange = move |change| set_text.set(input_value(change))
+            onkeydown = move |keypress| {
                 if keypress.key() == "Enter" {
                     let value = input_value(keypress);
                     let trimmed = value.trim();
@@ -36,6 +36,6 @@ pub fn text_input(
                     }
                     clear_text.set("".into());
                 }
-            }} />
+            } />
     }
 }

--- a/dom/examples/todo/src/item.rs
+++ b/dom/examples/todo/src/item.rs
@@ -31,7 +31,7 @@ fn item_with_buttons(todo: Todo, editing: Key<bool>) -> Div {
     let id = todo.id;
     let toggle_todos = todos.clone();
 
-    let on_click = move |_| {
+    let onclick = move |_| {
         toggle_todos.update(|t| {
             Some(
                 t.iter()
@@ -51,9 +51,9 @@ fn item_with_buttons(todo: Todo, editing: Key<bool>) -> Div {
 
     mox! {
         <div class="view">
-            <input class="toggle" type="checkbox" checked={todo.completed} onclick={on_click} />
+            <input class="toggle" type="checkbox" checked=todo.completed onclick />
 
-            <label ondblclick={move |_| editing.set(true)}>
+            <label ondblclick = move |_| editing.set(true)>
                 { todo.title }
             </label>
 

--- a/dom/examples/todo/src/item.rs
+++ b/dom/examples/todo/src/item.rs
@@ -54,7 +54,7 @@ fn item_with_buttons(todo: Todo, editing: Key<bool>) -> Div {
             <input class="toggle" type="checkbox" checked={todo.completed} onclick={on_click} />
 
             <label ondblclick={move |_| editing.set(true)}>
-                {% "{}", todo.title }
+                { todo.title }
             </label>
 
             <button class="destroy" onclick={move |_| {

--- a/dom/examples/todo/src/item.rs
+++ b/dom/examples/todo/src/item.rs
@@ -31,7 +31,7 @@ fn item_with_buttons(todo: Todo, editing: Key<bool>) -> Div {
     let id = todo.id;
     let toggle_todos = todos.clone();
 
-    let onclick = move |_| {
+    let toggle_completion = move |_| {
         toggle_todos.update(|t| {
             Some(
                 t.iter()
@@ -51,7 +51,7 @@ fn item_with_buttons(todo: Todo, editing: Key<bool>) -> Div {
 
     mox! {
         <div class="view">
-            <input class="toggle" type="checkbox" checked=todo.completed onclick />
+            <input class="toggle" type="checkbox" checked=todo.completed onclick=toggle_completion />
 
             <label ondblclick = move |_| editing.set(true)>
                 { todo.title }

--- a/dom/examples/todo/src/main_section.rs
+++ b/dom/examples/todo/src/main_section.rs
@@ -9,7 +9,7 @@ use moxie_dom::{
 #[illicit::from_env(todos: &Key<Vec<Todo>>)]
 pub fn toggle(default_checked: bool) -> Span {
     let todos = todos.clone();
-    let on_click = move |_| {
+    let onclick = move |_| {
         todos.update(|t| {
             Some(
                 t.iter()
@@ -25,8 +25,8 @@ pub fn toggle(default_checked: bool) -> Span {
 
     mox! {
         <span>
-            <input class="toggle-all" type="checkbox" checked={default_checked} />
-            <label onclick={on_click}/>
+            <input class="toggle-all" type="checkbox" checked=default_checked />
+            <label onclick />
         </span>
     }
 }

--- a/dom/src/interfaces/node.rs
+++ b/dom/src/interfaces/node.rs
@@ -40,7 +40,26 @@ pub trait NodeWrapper: sealed::Memoized + Sized {
 pub trait Child {
     /// Returns the "raw" node for this child to bind to its parent.
     fn to_bind(&self) -> &augdom::Node;
+
+    /// Identity transform
+    fn into_child(self) -> Self
+    where
+        Self: Sized,
+    {
+        self
+    }
 }
+
+/// Convert `impl std::fmt::Display` into the `impl Child`
+pub trait DisplayIntoChild: std::fmt::Display + Sized {
+    /// Wrap `impl std::fmt::Display` into the `text` node
+    fn into_child(self) -> crate::text::Text {
+        // TODO rely on format_args, see [`(fmt_as_str #74442)`](https://github.com/rust-lang/rust/issues/74442)
+        crate::text::text(format!("{}", self))
+    }
+}
+
+impl<T> DisplayIntoChild for T where T: std::fmt::Display + Sized {}
 
 impl<N> Child for N
 where

--- a/dom/src/interfaces/node.rs
+++ b/dom/src/interfaces/node.rs
@@ -41,7 +41,8 @@ pub trait Child {
     /// Returns the "raw" node for this child to bind to its parent.
     fn to_bind(&self) -> &augdom::Node;
 
-    /// Identity transform
+    /// Identity transform used to satisfy `mox!`'s syntax contract for a value to be used
+    /// directly as a child.
     fn into_child(self) -> Self
     where
         Self: Sized,
@@ -50,7 +51,8 @@ pub trait Child {
     }
 }
 
-/// Convert `impl std::fmt::Display` into the `impl Child`
+/// Allows values which `impl Display` to be used directly as `mox!` children,
+/// converting them into text nodes.
 pub trait DisplayIntoChild: std::fmt::Display + Sized {
     /// Wrap `impl std::fmt::Display` into the `text` node
     fn into_child(self) -> crate::text::Text {

--- a/dom/src/lib.rs
+++ b/dom/src/lib.rs
@@ -33,7 +33,7 @@ pub mod prelude {
             event_target::EventTarget as _,
             global_events::{GlobalEvent as _, GlobalEventHandler as _},
             html_element::HtmlElementBuilder,
-            node::{Child as _, DisplayIntoChild as _, NodeWrapper, Parent as _},
+            node::{Child as _, NodeWrapper, Parent as _, TextChild as _},
         },
         text::text,
         Stateful,

--- a/dom/src/lib.rs
+++ b/dom/src/lib.rs
@@ -33,7 +33,7 @@ pub mod prelude {
             event_target::EventTarget as _,
             global_events::{GlobalEvent as _, GlobalEventHandler as _},
             html_element::HtmlElementBuilder,
-            node::{NodeWrapper, Parent as _},
+            node::{Child as _, DisplayIntoChild as _, NodeWrapper, Parent as _},
         },
         text::text,
         Stateful,

--- a/dom/tests/custom_component.rs
+++ b/dom/tests/custom_component.rs
@@ -46,7 +46,7 @@ impl CounterBuilder {
         let text = text.unwrap_or_default();
 
         let button = mox! {
-            <button onclick={move |_| set_value.update(|n| Some(n + 1))}>
+            <button onclick = move |_| set_value.update(|n| Some(n + 1))>
                 {format_args!("{} ({})", text, value)}
             </button>
         };

--- a/dom/tests/custom_component.rs
+++ b/dom/tests/custom_component.rs
@@ -47,7 +47,7 @@ impl CounterBuilder {
 
         let button = mox! {
             <button onclick = move |_| set_value.update(|n| Some(n + 1))>
-                {format_args!("{} ({})", text, value)}
+                {% "{} ({})", text, value }
             </button>
         };
 

--- a/dom/tests/custom_component.rs
+++ b/dom/tests/custom_component.rs
@@ -47,7 +47,7 @@ impl CounterBuilder {
 
         let button = mox! {
             <button onclick={move |_| set_value.update(|n| Some(n + 1))}>
-                {% "{} ({})", text, value }
+                {format_args!("{} ({})", text, value)}
             </button>
         };
 

--- a/mox/CHANGELOG.md
+++ b/mox/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Added
 
-- "Attribute init shorthand" allows pulling an attribute from an identically-named binding n the
+- "Attribute init shorthand" allows pulling an attribute from an identically-named binding in the
   local scope:
 
   ```rust

--- a/mox/CHANGELOG.md
+++ b/mox/CHANGELOG.md
@@ -7,8 +7,28 @@
 
 <!-- categories: Added, Removed, Changed, Deprecated, Fixed, Security -->
 
-## [0.10.0] - unreleased
+## [0.11.0] - 2021-01-10
 
+### Added
+
+- "Attribute init shorthand" allows pulling an attribute from an identically-named binding n the
+  local scope:
+
+  ```rust
+  let onclick = |_| { ... };
+  mox!(<button onclick>"click me?"</button>)
+  ```
+
+- Module-nested tag names: `mox!(<krate::module::tag>"foo"</krate::module::tag>)`.
+- Attributes support single-expression values without braces: `<button disabled=true/>`.
+- XML comments: `mox!(<div> <!-- COMMENT HERE --> </div>)`.
+
+### Changed
+
+- `mox!` invocations are now lexed by the [syn-rsx](https://docs.rs/syn-rsx) crate.
+- Non-tag children have `.into_child()` appended to them.
+
+## [0.10.0] - 2020-07-06
 ### Removed
 
 - Support for `_=(...)` style function invocation in tags.

--- a/mox/Cargo.toml
+++ b/mox/Cargo.toml
@@ -14,10 +14,8 @@ authors = ["Adam Perry <lol@anp.lol>"]
 edition = "2018"
 
 [dependencies]
-mox-impl = { path = "impl", version = "0.10.0"}
-proc-macro-hack = "0.5"
-proc-macro-nested = "0.1.3"
-topo = { path = "../topo", version = "0.13.1"}
+mox-impl = { path = "impl", version = "0.10.0" }
+topo = { path = "../topo", version = "0.13.1" }
 
 [dev-dependencies]
 derive_builder = "0.9"

--- a/mox/Cargo.toml
+++ b/mox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mox"
-version = "0.10.0"
+version = "0.11.0"
 description = "Mockery Of X(ML): a JSX-alike syntax for the builder pattern."
 categories = ["gui", "rust-patterns"]
 keywords = ["jsx", "xml", "builder"]
@@ -14,7 +14,7 @@ authors = ["Adam Perry <lol@anp.lol>"]
 edition = "2018"
 
 [dependencies]
-mox-impl = { path = "impl", version = "0.10.0" }
+mox-impl = { path = "impl", version = "0.11.0"}
 topo = { path = "../topo", version = "0.13.1" }
 
 [dev-dependencies]

--- a/mox/impl/Cargo.toml
+++ b/mox/impl/Cargo.toml
@@ -18,6 +18,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-proc-macro-error = "1.0.0"
 quote = "1"
-snax = "0.3.0"
+syn-rsx = "0.7.3"
+syn = "^1"

--- a/mox/impl/Cargo.toml
+++ b/mox/impl/Cargo.toml
@@ -19,5 +19,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn-rsx = "0.7.3"
+syn-rsx = "0.8.0-beta.2"
 syn = "^1"

--- a/mox/impl/Cargo.toml
+++ b/mox/impl/Cargo.toml
@@ -19,6 +19,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 proc-macro-error = "1.0.0"
-proc-macro-hack = "0.5"
 quote = "1"
 snax = "0.3.0"

--- a/mox/impl/Cargo.toml
+++ b/mox/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mox-impl"
-version = "0.10.0"
+version = "0.11.0"
 description = "Implementation for the mox! macro."
 categories = ["gui", "rust-patterns"]
 keywords = ["jsx", "xml", "builder"]

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -1,244 +1,240 @@
 extern crate proc_macro;
 
-use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use proc_macro_error::{abort, emit_error, proc_macro_error, Diagnostic, Level, ResultExt};
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use snax::{ParseError, SnaxAttribute, SnaxFragment, SnaxItem, SnaxSelfClosingTag, SnaxTag};
-use std::borrow::Cow;
+use std::convert::TryFrom;
+use syn::{parse::Parse, parse_macro_input, spanned::Spanned};
 
 #[proc_macro]
-#[proc_macro_error(allow_not_macro)]
 pub fn mox(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let item = snax::parse(input.into()).map_err(Error::SnaxError).unwrap_or_abort();
-    let item = MoxItem::from(item);
+    let item = parse_macro_input!(input as MoxItem);
     quote!(#item).into()
 }
 
 enum MoxItem {
     Tag(MoxTag),
-    TagNoChildren(MoxTagNoChildren),
-    Fragment(Vec<MoxItem>),
-    Content { span: Span, stream: TokenStream },
+    Expr(MoxExpr),
 }
 
-impl MoxItem {
-    fn span(&self) -> Span {
-        match self {
-            MoxItem::Tag(tag) => tag.span(),
-            MoxItem::TagNoChildren(tag) => tag.span(),
-            MoxItem::Content { span, .. } => *span,
-            MoxItem::Fragment(_children) => todo!(),
+struct MoxTag {
+    name: syn::ExprPath,
+    attributes: Vec<MoxAttr>,
+    children: Vec<MoxItem>,
+}
+
+struct MoxAttr {
+    name: syn::Ident,
+    value: Option<syn::Expr>,
+}
+
+struct MoxExpr {
+    expr: syn::Expr,
+}
+
+impl Parse for MoxItem {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let parse_config = syn_rsx::ParserConfig::new()
+            .number_of_top_level_nodes(1)
+            .type_of_top_level_nodes(syn_rsx::NodeType::Element);
+        let parser = syn_rsx::Parser::new(parse_config);
+        let node = parser.parse(input)?.remove(0);
+
+        MoxItem::try_from(node)
+    }
+}
+
+impl TryFrom<syn_rsx::Node> for MoxItem {
+    type Error = syn::parse::Error;
+
+    fn try_from(node: syn_rsx::Node) -> syn::Result<Self> {
+        use syn_rsx::NodeType::*;
+        match node.node_type {
+            Element => MoxTag::try_from(node).map(MoxItem::Tag),
+            Attribute => Err(node_parse_error(&node, "MoxItem")),
+            Text | Block => MoxExpr::try_from(node).map(MoxItem::Expr),
         }
     }
 }
 
-impl From<SnaxItem> for MoxItem {
-    fn from(item: SnaxItem) -> Self {
-        match item {
-            SnaxItem::Tag(t) => MoxItem::Tag(MoxTag::from(t)),
-            SnaxItem::SelfClosingTag(t) => MoxItem::TagNoChildren(MoxTagNoChildren::from(t)),
-            SnaxItem::Fragment(SnaxFragment { children }) => {
-                MoxItem::Fragment(children.into_iter().map(MoxItem::from).collect())
+impl TryFrom<syn_rsx::Node> for MoxTag {
+    type Error = syn::parse::Error;
+
+    fn try_from(mut node: syn_rsx::Node) -> syn::Result<Self> {
+        use syn_rsx::NodeType::*;
+        match node.node_type {
+            Element => Ok({
+                let attributes: syn::Result<Vec<MoxAttr>> =
+                    node.attributes.drain(..).map(|node| MoxAttr::try_from(node)).collect();
+                let attributes = attributes?;
+
+                let children: syn::Result<Vec<MoxItem>> =
+                    node.children.drain(..).map(|node| MoxItem::try_from(node)).collect();
+                let children = children?;
+
+                Self { name: MoxTag::validate_name(node.name.unwrap())?, attributes, children }
+            }),
+            Attribute | Text | Block => Err(node_parse_error(&node, "MoxTag")),
+        }
+    }
+}
+
+impl MoxTag {
+    fn validate_name(name: syn_rsx::NodeName) -> syn::Result<syn::ExprPath> {
+        use syn::parse::Error;
+        use syn_rsx::NodeName;
+
+        match name {
+            NodeName::Path(mut expr_path) => {
+                mangle_expr_path(&mut expr_path);
+                Ok(expr_path)
             }
-            SnaxItem::Content(atom) => {
-                MoxItem::Content { span: atom.span(), stream: wrap_content_tokens(atom) }
+            NodeName::Dash(punctuated) => {
+                Err(Error::new(punctuated.span(), "Dash tag name syntax isn't supported"))
+            }
+            NodeName::Colon(punctuated) => {
+                Err(Error::new(punctuated.span(), "Colon tag name syntax isn't supported"))
             }
         }
     }
 }
 
-fn wrap_content_tokens(tt: TokenTree) -> TokenStream {
-    let mut new_stream = quote!(#tt);
-    match tt {
-        TokenTree::Group(g) => {
-            let mut tokens = g.stream().into_iter();
-            if let Some(TokenTree::Punct(p)) = tokens.next() {
-                if p.as_char() == '%' {
-                    // strip the percent sign off the front
-                    new_stream = TokenStream::new();
-                    new_stream.extend(tokens);
-                    new_stream = quote!(text(format!(#new_stream)));
+fn mangle_expr_path(name: &mut syn::ExprPath) {
+    for segment in name.path.segments.iter_mut() {
+        mangle_ident(&mut segment.ident);
+    }
+}
+
+impl TryFrom<syn_rsx::Node> for MoxAttr {
+    type Error = syn::parse::Error;
+
+    fn try_from(node: syn_rsx::Node) -> syn::Result<Self> {
+        use syn_rsx::NodeType::*;
+        match node.node_type {
+            Element | Text | Block => Err(node_parse_error(&node, "MoxAttr")),
+            Attribute => {
+                Ok(MoxAttr { name: MoxAttr::validate_name(node.name.unwrap())?, value: node.value })
+            }
+        }
+    }
+}
+
+impl MoxAttr {
+    fn validate_name(name: syn_rsx::NodeName) -> syn::Result<syn::Ident> {
+        use syn::{parse::Error, punctuated::Pair, PathSegment};
+        use syn_rsx::NodeName;
+
+        let invalid_error = |span| Error::new(span, "Invalid name for an attribute");
+
+        match name {
+            NodeName::Path(syn::ExprPath {
+                attrs,
+                qself: None,
+                path: syn::Path { leading_colon: None, mut segments },
+            }) if attrs.is_empty() && segments.len() == 1 => {
+                let pair = segments.pop();
+                match pair {
+                    Some(Pair::End(PathSegment { mut ident, arguments }))
+                        if arguments.is_empty() =>
+                    {
+                        mangle_ident(&mut ident);
+                        Ok(ident)
+                    }
+                    _ => Err(invalid_error(segments.span())),
                 }
             }
+            NodeName::Dash(punctuated) => {
+                Err(Error::new(punctuated.span(), "Dash attribute name syntax isn't supported"))
+            }
+            NodeName::Colon(punctuated) => {
+                Err(Error::new(punctuated.span(), "Colon attribute name syntax isn't supported"))
+            }
+            name => Err(invalid_error(name.span())),
         }
-        tt @ TokenTree::Ident(_) | tt @ TokenTree::Literal(_) => {
-            new_stream = quote!(text(#tt));
-        }
-        TokenTree::Punct(p) => emit_error!(p.span(), "'{}' not valid in item position", p),
     }
-    new_stream
+}
+
+fn mangle_ident(ident: &mut syn::Ident) {
+    let name = ident.to_string();
+    match name.as_str() {
+        "async" | "for" | "loop" | "type" => *ident = syn::Ident::new(&(name + "_"), ident.span()),
+        _ => (),
+    }
+}
+
+impl TryFrom<syn_rsx::Node> for MoxExpr {
+    type Error = syn::parse::Error;
+
+    fn try_from(node: syn_rsx::Node) -> syn::Result<Self> {
+        use syn_rsx::NodeType::*;
+        match node.node_type {
+            Element | Attribute => Err(node_parse_error(&node, "MoxExpr")),
+            Text | Block => Ok(MoxExpr { expr: node.value.unwrap() }),
+        }
+    }
+}
+
+fn node_parse_error(node: &syn_rsx::Node, failed: &'static str) -> syn::parse::Error {
+    use syn_rsx::NodeType::*;
+    syn::parse::Error::new(node_span(&node), match node.node_type {
+        Element => format!("Cannot parse element as a {}", failed),
+        Attribute => format!("Cannot parse attribute as a {}", failed),
+        Text => format!("Cannot parse text as a {}", failed),
+        Block => format!("Cannot parse block as a {}", failed),
+    })
+}
+
+fn node_span(syn_rsx::Node { name, value, node_type, .. }: &syn_rsx::Node) -> Span {
+    use syn_rsx::NodeType::*;
+    // TODO get the span for the whole tag, see `https://github.com/rust-lang/rust/issues/54725`
+    match node_type {
+        Element | Attribute => name.as_ref().unwrap().span(),
+        Text | Block => value.as_ref().unwrap().span(),
+    }
 }
 
 impl ToTokens for MoxItem {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             MoxItem::Tag(tag) => tag.to_tokens(tokens),
-            MoxItem::TagNoChildren(tag) => tag.to_tokens(tokens),
-            MoxItem::Content { stream, .. } => stream.to_tokens(tokens),
-            MoxItem::Fragment(_children) => todo!(),
+            MoxItem::Expr(expr) => expr.to_tokens(tokens),
         }
-    }
-}
-
-struct MoxTag {
-    span: Span,
-    name: Ident,
-    attributes: Vec<MoxAttr>,
-    children: Vec<MoxItem>,
-}
-
-impl MoxTag {
-    fn span(&self) -> Span {
-        self.span
     }
 }
 
 impl ToTokens for MoxTag {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tag_to_tokens(&self.name, &self.attributes, Some(&self.children), tokens);
-    }
-}
+        let MoxTag { name, attributes, children } = self;
 
-fn tag_to_tokens(
-    name: &Ident,
-    attributes: &[MoxAttr],
-    children: Option<&[MoxItem]>,
-    stream: &mut TokenStream,
-) {
-    // this needs to be nested within other token groups, must be accumulated
-    // separately from stream
-    let mut contents = quote!();
+        // this needs to be nested within other token groups, must be accumulated
+        // separately from stream
+        let mut contents = quote!();
 
-    for attr in attributes {
-        attr.to_tokens(&mut contents);
-    }
-
-    if let Some(items) = children {
-        for child in items {
-            MoxAttr::child(child).to_tokens(&mut contents);
+        for attr in attributes {
+            attr.to_tokens(&mut contents);
         }
-    }
 
-    quote!(mox::topo::call(|| { #name() #contents .build() })).to_tokens(stream);
-}
-
-impl From<SnaxTag> for MoxTag {
-    fn from(SnaxTag { name, attributes, children }: SnaxTag) -> Self {
-        let attributes = attributes.into_iter().map(MoxAttr::from).collect();
-        Self {
-            // TODO get the span for the whole tag
-            span: name.span(),
-            name,
-            attributes,
-            children: children.into_iter().map(MoxItem::from).collect(),
+        for child in children {
+            quote!(.child(#child)).to_tokens(&mut contents);
         }
-    }
-}
 
-struct MoxTagNoChildren {
-    span: Span,
-    name: Ident,
-    attributes: Vec<MoxAttr>,
-}
-
-impl MoxTagNoChildren {
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl ToTokens for MoxTagNoChildren {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tag_to_tokens(&self.name, &self.attributes, None, tokens);
-    }
-}
-
-impl From<SnaxSelfClosingTag> for MoxTagNoChildren {
-    fn from(SnaxSelfClosingTag { name, attributes }: SnaxSelfClosingTag) -> Self {
-        let attributes = attributes.into_iter().map(MoxAttr::from).collect();
-        Self { span: name.span(), name, attributes }
-    }
-}
-
-struct MoxAttr {
-    name: Ident,
-    value: TokenStream,
-}
-
-impl MoxAttr {
-    fn child(item: &MoxItem) -> Self {
-        Self { name: Ident::new("child", item.span()), value: item.to_token_stream() }
+        quote!(mox::topo::call(|| { #name() #contents .build() })).to_tokens(tokens);
     }
 }
 
 impl ToTokens for MoxAttr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Self { name, value } = self;
-        let name = mangle_keywords(name);
+        let value = match value {
+            Some(value) => value.to_token_stream(),
+            None => quote! {()},
+        };
         tokens.extend(quote!(.#name(#value)));
     }
 }
 
-fn mangle_keywords(name: &Ident) -> Cow<'_, Ident> {
-    let replacement = if name == "async" {
-        Some("async_")
-    } else if name == "for" {
-        Some("for_")
-    } else if name == "loop" {
-        Some("loop_")
-    } else if name == "type" {
-        Some("type_")
-    } else {
-        None
-    };
-
-    match replacement {
-        Some(r) => Cow::Owned(Ident::new(r, name.span())),
-        None => Cow::Borrowed(name),
-    }
-}
-
-impl From<SnaxAttribute> for MoxAttr {
-    fn from(attr: SnaxAttribute) -> Self {
-        match attr {
-            SnaxAttribute::Simple { name, value } => {
-                let name_str = name.to_string();
-                if name_str == "_" {
-                    abort!(
-                        name.span(),
-                        "anonymous attributes are only allowed in the first position"
-                    )
-                } else {
-                    MoxAttr {
-                        name,
-                        value: match value {
-                            TokenTree::Group(g) => g.stream(),
-                            other => other.to_token_stream(),
-                        },
-                    }
-                }
-            }
-        }
-    }
-}
-
-enum Error {
-    SnaxError(ParseError),
-}
-
-impl Into<Diagnostic> for Error {
-    fn into(self) -> Diagnostic {
-        match self {
-            Error::SnaxError(ParseError::UnexpectedEnd) => {
-                Diagnostic::new(Level::Error, "input ends before expected".to_string())
-            }
-            Error::SnaxError(ParseError::UnexpectedItem(item)) => {
-                // TODO(#96)
-                Diagnostic::new(Level::Error, format!("did not expect {:?}", item))
-            }
-            Error::SnaxError(ParseError::UnexpectedToken(token)) => {
-                Diagnostic::new(Level::Error, format!("did not expect '{}'", token))
-            }
-        }
+impl ToTokens for MoxExpr {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { expr } = self;
+        quote!(#expr.into_child()).to_tokens(tokens);
     }
 }

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -2,13 +2,12 @@ extern crate proc_macro;
 
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use proc_macro_error::{abort, emit_error, proc_macro_error, Diagnostic, Level, ResultExt};
-use proc_macro_hack::proc_macro_hack;
 use quote::{quote, ToTokens};
 use snax::{ParseError, SnaxAttribute, SnaxFragment, SnaxItem, SnaxSelfClosingTag, SnaxTag};
 use std::borrow::Cow;
 
+#[proc_macro]
 #[proc_macro_error(allow_not_macro)]
-#[proc_macro_hack]
 pub fn mox(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let item = snax::parse(input.into()).map_err(Error::SnaxError).unwrap_or_abort();
     let item = MoxItem::from(item);

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -143,7 +143,10 @@ impl ToTokens for MoxTag {
         }
 
         for child in children {
-            quote!(.child(#child)).to_tokens(&mut contents);
+            match child {
+                MoxItem::None => (),
+                nonempty_child => quote!(.child(#nonempty_child)).to_tokens(&mut contents),
+            }
         }
 
         // TODO remove `topo` dependency, see `https://github.com/anp/moxie/issues/199`

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -224,7 +224,7 @@ trait NodeConvertError {
 impl<T> NodeConvertError for T where T: TryFrom<syn_rsx::Node> {}
 
 fn node_span(node: &syn_rsx::Node) -> Span {
-    // TODO get the span for the whole node, see `https://github.com/stoically/syn-rsx/issues/4`
+    // TODO get the span for the whole node, see `https://github.com/stoically/syn-rsx/issues/14`
     // Prioritize name's span then value's span then call site's span.
     node.name_span()
         .or_else(|| node.value.as_ref().map(|value| value.span()))

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -224,11 +224,10 @@ impl ToTokens for MoxTag {
 impl ToTokens for MoxAttr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Self { name, value } = self;
-        let value = match value {
-            Some(value) => value.to_token_stream(),
-            None => quote! {()},
+        match value {
+            Some(value) => tokens.extend(quote!(.#name(#value))),
+            None => tokens.extend(quote!(.#name(#name))),
         };
-        tokens.extend(quote!(.#name(#value)));
     }
 }
 

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -285,3 +285,43 @@ fn node_span(node: &syn_rsx::Node) -> Span {
         .or_else(|| node.value.as_ref().map(|value| value.span()))
         .unwrap_or_else(Span::call_site)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn fail_colon_tag_names() {
+        let input = quote! { <colon:tag:name /> };
+        syn::parse2::<MoxItem>(input).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_block_tag_names() {
+        let input = quote! { <{"block tag name"} /> };
+        syn::parse2::<MoxItem>(input).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_colon_attribute_names() {
+        let input = quote! { <some::tag colon:attribute:name=() /> };
+        syn::parse2::<MoxItem>(input).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_path_attribute_names() {
+        let input = quote! { <some::tag path::attribute::name=() /> };
+        syn::parse2::<MoxItem>(input).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_format_expression() {
+        let input = quote! { {% "1: {}; 2: {}", var1, var2 tail } };
+        syn::parse2::<MoxItem>(input).unwrap();
+    }
+}

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -287,41 +287,20 @@ fn node_span(node: &syn_rsx::Node) -> Span {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[should_panic]
-    fn fail_colon_tag_names() {
-        let input = quote! { <colon:tag:name /> };
-        syn::parse2::<MoxItem>(input).unwrap();
+#[test]
+fn fails() {
+    fn assert_error(input: TokenStream) {
+        match syn::parse2::<MoxItem>(input) {
+            Ok(_) => unreachable!(),
+            Err(error) => println!("{}", error),
+        }
     }
 
-    #[test]
-    #[should_panic]
-    fn fail_block_tag_names() {
-        let input = quote! { <{"block tag name"} /> };
-        syn::parse2::<MoxItem>(input).unwrap();
-    }
-
-    #[test]
-    #[should_panic]
-    fn fail_colon_attribute_names() {
-        let input = quote! { <some::tag colon:attribute:name=() /> };
-        syn::parse2::<MoxItem>(input).unwrap();
-    }
-
-    #[test]
-    #[should_panic]
-    fn fail_path_attribute_names() {
-        let input = quote! { <some::tag path::attribute::name=() /> };
-        syn::parse2::<MoxItem>(input).unwrap();
-    }
-
-    #[test]
-    #[should_panic]
-    fn fail_format_expression() {
-        let input = quote! { {% "1: {}; 2: {}", var1, var2 tail } };
-        syn::parse2::<MoxItem>(input).unwrap();
-    }
+    println!();
+    assert_error(quote! { <colon:tag:name /> });
+    assert_error(quote! { <{"block tag name"} /> });
+    assert_error(quote! { <some::tag colon:attribute:name=() /> });
+    assert_error(quote! { <some::tag path::attribute::name=() /> });
+    assert_error(quote! { {% "1: {}; 2: {}", var1, var2 tail } });
+    println!();
 }

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -173,6 +173,7 @@ impl MoxAttr {
                         mangle_ident(&mut ident);
                         Ok(ident)
                     }
+                    // TODO improve error handling, see `https://github.com/stoically/syn-rsx/issues/12`
                     _ => Err(invalid_error(segments.span())),
                 }
             }
@@ -256,6 +257,7 @@ impl ToTokens for MoxTag {
             quote!(.child(#child)).to_tokens(&mut contents);
         }
 
+        // TODO remove `topo` dependency, see `https://github.com/anp/moxie/issues/199`
         quote!(mox::topo::call(|| { #name() #contents .build() })).to_tokens(tokens);
     }
 }

--- a/mox/impl/src/lib.rs
+++ b/mox/impl/src/lib.rs
@@ -49,7 +49,7 @@ impl Parse for MoxItem {
 }
 
 impl TryFrom<syn_rsx::Node> for MoxItem {
-    type Error = syn::parse::Error;
+    type Error = SynError;
 
     fn try_from(node: syn_rsx::Node) -> syn::Result<Self> {
         match node.node_type {
@@ -61,7 +61,7 @@ impl TryFrom<syn_rsx::Node> for MoxItem {
 }
 
 impl TryFrom<syn_rsx::Node> for MoxTag {
-    type Error = syn::parse::Error;
+    type Error = SynError;
 
     fn try_from(mut node: syn_rsx::Node) -> syn::Result<Self> {
         match node.node_type {
@@ -110,7 +110,7 @@ fn mangle_expr_path(name: &mut syn::ExprPath) {
 }
 
 impl TryFrom<syn_rsx::Node> for MoxAttr {
-    type Error = syn::parse::Error;
+    type Error = SynError;
 
     fn try_from(node: syn_rsx::Node) -> syn::Result<Self> {
         match node.node_type {
@@ -168,7 +168,7 @@ fn mangle_ident(ident: &mut syn::Ident) {
 }
 
 impl TryFrom<syn_rsx::Node> for MoxExpr {
-    type Error = syn::parse::Error;
+    type Error = SynError;
 
     fn try_from(node: syn_rsx::Node) -> syn::Result<Self> {
         match node.node_type {
@@ -178,7 +178,7 @@ impl TryFrom<syn_rsx::Node> for MoxExpr {
     }
 }
 
-fn node_parse_error(node: &syn_rsx::Node, mox_type_name: &'static str) -> syn::parse::Error {
+fn node_parse_error(node: &syn_rsx::Node, mox_type_name: &'static str) -> SynError {
     SynError::new(
         node_span(&node),
         format!("Cannot parse {} as a {}", node.node_type, mox_type_name),

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -60,6 +60,9 @@
 /// Literals and expressions have `.into_child()` appended to them before being
 /// passed to `.child(...)`.
 ///
+/// Block expressions can optionally be opened with `{%` to denote a "formatter"
+/// item. The enclosed tokens are passed to the `format_args!` macro.
+///
 /// ## Fragments
 ///
 /// Fragments are opened with `<>` and closed with `</>`. Their only purpose is

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -22,7 +22,8 @@
 ///
 /// ## Fragments
 ///
-/// Fragments are not yet supported. Depends on [this issue](https://github.com/stoically/syn-rsx/issues/8).
+/// Fragments are not yet supported. See [this issue](https://github.com/anp/moxie/issues/232)
+/// for discussion.
 ///
 /// ## Content/Text
 ///

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -127,7 +127,6 @@
 /// ```
 ///
 /// [JSX]: https://facebook.github.io/jsx/
-#[proc_macro_hack::proc_macro_hack(support_nested)]
 pub use mox_impl::mox;
 
 #[doc(hidden)]

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -25,14 +25,6 @@
 /// Fragments are not yet supported. See [this issue](https://github.com/anp/moxie/issues/232)
 /// for discussion.
 ///
-/// ## Content/Text
-///
-/// Any child that is not a tag but some sort of an expression (see below)
-/// additionally is calling `.into_child()` method.
-///
-/// You can pass a string literal (`"text"`) or expression (`{format!(...)}`) as
-/// a text. Make sure required methods are implemented.
-///
 /// # Inputs
 ///
 /// Each macro invocation must resolve to a single item. Items can be tags,
@@ -62,16 +54,17 @@
 ///
 /// If there are no children the tag can be "self-closing": `<NAME ... />`.
 ///
+/// Each child can be either another tag, a Rust literal, or a Rust block (an
+/// expression wrapped in `{` and `}`).
+///
+/// Literals and expressions have `.into_child()` appended to them before being
+/// passed to `.child(...)`.
+///
 /// ## Fragments
 ///
 /// Fragments are opened with `<>` and closed with `</>`. Their only purpose is
 /// to provide a parent for children. They do not accept arguments or
 /// attributes.
-///
-/// ## Expressions
-///
-/// Raw Rust expressions can be inserted as a child node. They have to be a
-/// literal or be delimited with `{` and `}`.
 ///
 /// # Example
 ///

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -109,6 +109,7 @@
 /// assert_eq!(
 ///     mox! {
 ///         <built name="alice">
+///             <!-- "This is a comment" -->
 ///             <built name="bob"/>
 ///         </built>
 ///     },

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -22,21 +22,22 @@
 ///
 /// ## Fragments
 ///
-/// Fragments are not currently supported.
+/// Fragments are not yet supported. Depends on [this issue](https://github.com/stoically/syn-rsx/issues/8).
 ///
 /// ## Content/Text
 ///
-/// Text nodes are wrapped in calls to `text(...)`.
+/// Any child that is not a tag but some sort of an expression (see below)
+/// additionally is calling `.into_child()` method.
 ///
-/// If an expression is a formatter, the arguments are wrapped
-/// in the `format!(...)` macro before being treated as a text node.
+/// You can pass a string literal (`"text"`) or expression (`{format!(...)}`) as
+/// a text. Make sure required methods are implemented.
 ///
 /// # Inputs
 ///
 /// Each macro invocation must resolve to a single item. Items can be tags,
 /// fragments, or content.
 ///
-/// [snax](https://docs.rs/snax) is used to tokenize the input as [JSX]\(ish\).
+/// [syn-rsx](https://docs.rs/syn-rsx) is used to tokenize the input as [JSX]\(ish\).
 ///
 /// ## Tags
 ///
@@ -68,13 +69,8 @@
 ///
 /// ## Expressions
 ///
-/// Raw Rust expressions can be inserted as a child node. They are delimited
-/// with `{` and `}`.
-///
-/// ## Format expressions
-///
-/// Expressions can optionally be opened with `{%` to denote a "formatter" item.
-/// The enclosed tokens are passed
+/// Raw Rust expressions can be inserted as a child node. They have to be a
+/// literal or be delimited with `{` and `}`.
 ///
 /// # Example
 ///

--- a/mox/tests/derive_builder.rs
+++ b/mox/tests/derive_builder.rs
@@ -14,6 +14,12 @@ struct ToBuild {
     children: Vec<ToBuild>,
 }
 
+impl ToBuild {
+    fn into_child(self) -> Self {
+        self
+    }
+}
+
 impl ToBuildBuilder {
     fn child(mut self, child: ToBuild) -> Self {
         let children = if let Some(c) = self.children.as_mut() {


### PR DESCRIPTION
Current implementation of the `mox` macro uses `snax` with `proc_macro_hack` crate. This causes rust-analyzer lining errors. For the reason of `snax` not being regularly supported i recommend to switch to the `syn_rsx` crate, which solves these problems and adds linting for the tags and attributes.

- [x] Update docs for the `mox` crate