### PR TITLE
[ci] Remove gnu-tar workaround.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,6 @@ jobs:
     - run: rustup install ${{ env.RUSTUP_TOOLCHAIN }}
     - name: ensure lockfile up to date
       run: cargo generate-lockfile --manifest-path ofl/Cargo.toml
-    - name: install gnu tar to work around https://github.com/actions/cache/issues/403
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install gnu-tar
-        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
     - uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-ofl-${{ hashFiles('ofl/Cargo.lock') }}-${{ env.RUSTUP_TOOLCHAIN }}
@@ -61,11 +56,6 @@ jobs:
 
     - name: ensure lockfile up to date
       run: cargo generate-lockfile
-    - name: install gnu tar to work around https://github.com/actions/cache/issues/403
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install gnu-tar
-        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
     - uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-coverage-${{ hashFiles('Cargo.lock') }}-${{ env.RUSTUP_TOOLCHAIN }}
@@ -104,11 +94,6 @@ jobs:
 
     - name: ensure lockfile up to date
       run: cargo generate-lockfile
-    - name: install gnu tar to work around https://github.com/actions/cache/issues/403
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install gnu-tar
-        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
     - uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-dom-${{ hashFiles('Cargo.lock') }}-${{ env.RUSTUP_TOOLCHAIN }}
@@ -151,11 +136,6 @@ jobs:
 
     - name: ensure lockfile up to date
       run: cargo generate-lockfile
-    - name: install gnu tar to work around https://github.com/actions/cache/issues/403
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install gnu-tar
-        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
     - uses: actions/cache@v2
       with:
         key: ${{ runner.os }}-website-${{ hashFiles('Cargo.lock') }}-${{ env.RUSTUP_TOOLCHAIN }}


### PR DESCRIPTION
It's now [installed on macOS images by default](https://github.com/actions/virtual-environments/issues/1534#issuecomment-771627280) and the [cache action has been updated to use it](https://github.com/actions/toolkit/pull/701). I think it's safe to remove all of our workaround configuration for the [issue](https://github.com/actions/cache/issues/403).