### PR TITLE
Hyphenated element and attribute names

### DIFF
--- a/dom/tests/custom_component.rs
+++ b/dom/tests/custom_component.rs
@@ -59,7 +59,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 pub async fn binds_to_div() {
-    let render_counter_as_child = || mox!(<div><custom-counter button_text="child" value=9/></div>);
+    let render_counter_as_child = || mox!(<div><custom-counter button-text="child" value=9/></div>);
     let test_root = document().create_element("div");
     moxie_dom::boot(test_root.clone(), render_counter_as_child);
 
@@ -73,7 +73,7 @@ pub async fn binds_to_div() {
 
 #[wasm_bindgen_test]
 pub async fn renders_and_interacts() {
-    let render_counter = || mox!(<custom-counter button_text="foo" value=0/>);
+    let render_counter = || mox!(<custom-counter button-text="foo" value=0/>);
     let test_root = document().create_element("div");
     moxie_dom::boot(test_root.clone(), render_counter);
 

--- a/dom/tests/custom_component.rs
+++ b/dom/tests/custom_component.rs
@@ -18,7 +18,7 @@ impl moxie_dom::interfaces::node::Child for Counter {
     }
 }
 
-fn counter() -> CounterBuilder {
+fn custom_counter() -> CounterBuilder {
     CounterBuilder::default()
 }
 
@@ -59,7 +59,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 pub async fn binds_to_div() {
-    let render_counter_as_child = || mox!(<div><counter button_text="child" value=9/></div>);
+    let render_counter_as_child = || mox!(<div><custom-counter button_text="child" value=9/></div>);
     let test_root = document().create_element("div");
     moxie_dom::boot(test_root.clone(), render_counter_as_child);
 
@@ -73,7 +73,7 @@ pub async fn binds_to_div() {
 
 #[wasm_bindgen_test]
 pub async fn renders_and_interacts() {
-    let render_counter = || mox!(<counter button_text="foo" value=0/>);
+    let render_counter = || mox!(<custom-counter button_text="foo" value=0/>);
     let test_root = document().create_element("div");
     moxie_dom::boot(test_root.clone(), render_counter);
 

--- a/dom/tests/dashes.rs
+++ b/dom/tests/dashes.rs
@@ -1,0 +1,35 @@
+//! These are compile time tests, but they shouldn't take any time to run, so we don't ignore them.
+use mox::mox;
+use moxie_dom::elements::html::div;
+
+fn unused<T>(_x: T) {}
+
+#[test]
+pub fn single_word() {
+    let custom_name = || div();
+    unused(|| mox!(<custom-name/>));
+}
+
+#[test]
+pub fn multi_word() {
+    let custom_multi_word_name = || div();
+    unused(|| mox!(<custom-multi-word-name></custom-multi-word-name>));
+}
+
+#[test]
+pub fn trailing_dash() {
+    let custom_trailing_dash_ = || div();
+    unused(|| mox!(<custom-trailing-dash-></custom-trailing-dash->));
+}
+
+#[test]
+pub fn keywords() {
+    let custom_for_loop_in_self = || div();
+    unused(|| mox!(<custom-for-loop-in-self></custom-for-loop-in-self>));
+}
+
+#[test]
+pub fn leading_keyword() {
+    let for_loop_in_self = || div();
+    unused(|| mox!(<for-loop-in-self></for-loop-in-self>));
+}

--- a/dom/tests/dashes.rs
+++ b/dom/tests/dashes.rs
@@ -5,15 +5,15 @@ use moxie_dom::elements::html::div;
 fn unused<T>(_x: T) {}
 
 #[test]
-pub fn single_word() {
+pub fn single_dash() {
     let custom_name = || div();
     unused(|| mox!(<custom-name/>));
 }
 
 #[test]
-pub fn multi_word() {
-    let custom_multi_word_name = || div();
-    unused(|| mox!(<custom-multi-word-name></custom-multi-word-name>));
+pub fn multi_dash() {
+    let custom_multi_dash_name = || div();
+    unused(|| mox!(<custom-multi-dash-name></custom-multi-dash-name>));
 }
 
 #[test]

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate proc_macro;
 
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::convert::TryFrom;
 use syn::{
@@ -10,7 +10,7 @@ use syn::{
     spanned::Spanned,
     token::Comma,
 };
-use syn_rsx::{NodeName, NodeType};
+use syn_rsx::{punctuation::Dash, NodeName, NodeType};
 
 /// Accepts an XML-like expression and expands it to builder method calls.
 ///
@@ -402,9 +402,7 @@ fn mangle_ident(ident: &mut syn::Ident) {
     }
 }
 
-fn dashes_to_underscores(
-    punctuated: Punctuated<proc_macro2::Ident, syn_rsx::punctuation::Dash>,
-) -> syn::Ident {
+fn dashes_to_underscores(punctuated: Punctuated<Ident, Dash>) -> syn::Ident {
     let mut words = punctuated.iter();
     let mut ident_name =
         words.next().expect("There must be at least one ident in a punctuated list").to_string();

--- a/mox/src/lib.rs
+++ b/mox/src/lib.rs
@@ -75,6 +75,12 @@ use syn_rsx::{NodeName, NodeType};
 /// Block expressions can optionally be opened with `{%` to denote a "formatter"
 /// item. The enclosed tokens are passed to the `format_args!` macro.
 ///
+/// ### Hyphenated Names
+///
+/// Tag and attribute names can by hyphenated. The underlying function and
+/// method names will have hyphens replaced with underscores. Multiple
+/// consecutive hyphens are not supported.
+///
 /// ## Fragments
 ///
 /// Fragments are opened with `<>` and closed with `</>`. Their only purpose is
@@ -238,8 +244,12 @@ impl MoxTag {
                 Ok(expr_path)
             }
             NodeName::Dash(punctuated) => {
-                // TODO support dash tag name syntax, see `https://github.com/anp/moxie/issues/233`
-                Err(syn::Error::new(punctuated.span(), "Dash tag name syntax isn't supported"))
+                let ident = dashes_to_underscores(punctuated);
+                let mut segments = Punctuated::new();
+                segments.push(ident.into());
+                let path = syn::Path { leading_colon: None, segments };
+
+                Ok(syn::ExprPath { attrs: vec![], qself: None, path })
             }
             NodeName::Colon(punctuated) => {
                 Err(syn::Error::new(punctuated.span(), "Colon tag name syntax isn't supported"))
@@ -321,13 +331,7 @@ impl MoxAttr {
                     _ => Err(invalid_error(segments.span())),
                 }
             }
-            NodeName::Dash(punctuated) => {
-                // TODO support dash tag name syntax, see `https://github.com/anp/moxie/issues/233`
-                Err(syn::Error::new(
-                    punctuated.span(),
-                    "Dash attribute name syntax isn't supported",
-                ))
-            }
+            NodeName::Dash(punctuated) => Ok(dashes_to_underscores(punctuated)),
             NodeName::Colon(punctuated) => Err(syn::Error::new(
                 punctuated.span(),
                 "Colon attribute name syntax isn't supported",
@@ -396,6 +400,25 @@ fn mangle_ident(ident: &mut syn::Ident) {
         "async" | "for" | "loop" | "type" => *ident = syn::Ident::new(&(name + "_"), ident.span()),
         _ => (),
     }
+}
+
+fn dashes_to_underscores(
+    punctuated: Punctuated<proc_macro2::Ident, syn_rsx::punctuation::Dash>,
+) -> syn::Ident {
+    let mut words = punctuated.iter();
+    let mut ident_name =
+        words.next().expect("There must be at least one ident in a punctuated list").to_string();
+
+    for w in words {
+        ident_name.push('_');
+        ident_name.push_str(&w.to_string());
+    }
+
+    if punctuated.trailing_punct() {
+        ident_name.push('_');
+    }
+
+    syn::Ident::new(&ident_name, punctuated.span())
 }
 
 fn node_span(node: &syn_rsx::Node) -> Span {

--- a/mox/tests/dashes.rs
+++ b/mox/tests/dashes.rs
@@ -1,35 +1,48 @@
 //! These are compile time tests, but they shouldn't take any time to run, so we don't ignore them.
 use mox::mox;
-use moxie_dom::elements::html::div;
+
+struct Tag();
+
+impl Tag {
+    fn single_dash(self, _value: &str) -> Self { self }
+
+    fn build(self) {}
+}
 
 fn unused<T>(_x: T) {}
 
 #[test]
 pub fn single_dash() {
-    let custom_name = || div();
+    let custom_name = || Tag();
     unused(|| mox!(<custom-name/>));
 }
 
 #[test]
+pub fn single_dash_attr() {
+    let tag = || Tag();
+    unused(|| mox!(<tag single-dash="testing"/>));
+}
+
+#[test]
 pub fn multi_dash() {
-    let custom_multi_dash_name = || div();
+    let custom_multi_dash_name = || Tag();
     unused(|| mox!(<custom-multi-dash-name></custom-multi-dash-name>));
 }
 
 #[test]
 pub fn trailing_dash() {
-    let custom_trailing_dash_ = || div();
+    let custom_trailing_dash_ = || Tag();
     unused(|| mox!(<custom-trailing-dash-></custom-trailing-dash->));
 }
 
 #[test]
 pub fn keywords() {
-    let custom_for_loop_in_self = || div();
+    let custom_for_loop_in_self = || Tag();
     unused(|| mox!(<custom-for-loop-in-self></custom-for-loop-in-self>));
 }
 
 #[test]
 pub fn leading_keyword() {
-    let for_loop_in_self = || div();
+    let for_loop_in_self = || Tag();
     unused(|| mox!(<for-loop-in-self></for-loop-in-self>));
 }

--- a/mox/tests/dashes.rs
+++ b/mox/tests/dashes.rs
@@ -4,7 +4,9 @@ use mox::mox;
 struct Tag();
 
 impl Tag {
-    fn single_dash(self, _value: &str) -> Self { self }
+    fn single_dash(self, _value: &str) -> Self {
+        self
+    }
 
     fn build(self) {}
 }


### PR DESCRIPTION
Fixes #233

`syn_rsx` doesn't support multiple consecutive dashes, so neither does this.