### PR TITLE
[core] Freshly initialized DepNodes should not propagate their liveness.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,7 @@ watch --clear
     -w illicit
     -w mox
     -w src
+    -w tests
     -w topo
     -w Cargo.toml
     -x clippy-core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 wasm-bindgen = [ "dyn-cache/wasm-bindgen", "parking_lot/wasm-bindgen", "topo/wasm-bindgen" ]
 
 [dependencies]
-dyn-cache = { path = "dyn-cache", version = "0.12.1"}
+dyn-cache = { path = "dyn-cache", version = "0.12.2"}
 futures = "0.3.5"
 illicit = { path = "illicit", version = "1.1.2"}
 moxie-macros = { path = "macros", version = "0.1.0-pre" }

--- a/dyn-cache/CHANGELOG.md
+++ b/dyn-cache/CHANGELOG.md
@@ -5,6 +5,14 @@ invocations.
 
 <!-- categories: Added, Removed, Changed, Deprecated, Fixed, Security -->
 
+## [0.12.2] - 2021-04-25
+
+### Fixed
+
+- Cached values no longer inherit liveness from their dependents if those dependents were
+  initialized in the current GC revision. This prevented some values from being GC'd at the correct
+  time. See [#238](https://github.com/anp/moxie/issues/238).
+
 ## [0.12.1] - 2020-12-28
 
 ### Added

--- a/dyn-cache/Cargo.toml
+++ b/dyn-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyn-cache"
-version = "0.12.1"
+version = "0.12.2"
 description = "Query cache indexed by type."
 categories = ["caching", "rust-patterns"]
 keywords = ["incremental", "memoize", "intern", "cache"]

--- a/dyn-cache/src/cache_cell.rs
+++ b/dyn-cache/src/cache_cell.rs
@@ -28,7 +28,7 @@ impl<Input, Output> CacheCell<Input, Output> {
         Arg: PartialEq<Input> + ?Sized,
         Input: Borrow<Arg>,
     {
-        self.dep.root(dependent);
+        self.dep.root_read(dependent);
         if input == &self.input {
             Ok(&self.output)
         } else {
@@ -37,8 +37,8 @@ impl<Input, Output> CacheCell<Input, Output> {
     }
 
     /// Store a new input/output and mark the storage live.
-    pub fn store(&mut self, input: Input, output: Output, dependent: Dependent) {
-        self.dep.root(dependent);
+    pub fn store(&mut self, input: Input, output: Output, dependent: Dependent, revision: u64) {
+        self.dep.root_write(dependent, revision);
         self.input = input;
         self.output = output;
     }
@@ -47,8 +47,8 @@ impl<Input, Output> CacheCell<Input, Output> {
         self.dep.is_known_live()
     }
 
-    pub fn update_liveness(&mut self) {
-        self.dep.update_liveness();
+    pub fn update_liveness(&mut self, current_revision: u64) {
+        self.dep.update_liveness(current_revision);
     }
 
     pub fn mark_dead(&mut self) {

--- a/dyn-cache/src/lib.rs
+++ b/dyn-cache/src/lib.rs
@@ -432,7 +432,7 @@ pub mod sync {
 /// A type which can contain values of varying liveness.
 trait Storage: Downcast + Debug {
     /// Traverse stored values, identifying roots.
-    fn mark(&mut self);
+    fn mark(&mut self, revision: u64);
 
     /// Remove dead entries.
     fn sweep(&mut self);

--- a/tests/issue_238.rs
+++ b/tests/issue_238.rs
@@ -1,0 +1,67 @@
+use moxie::{
+    cache, once,
+    runtime::{Revision, RunLoop},
+};
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
+
+struct CountDrops {
+    num_drops: Arc<AtomicU32>,
+}
+
+impl Drop for CountDrops {
+    fn drop(&mut self) {
+        self.num_drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn issue_238_cache_call_incorrectly_preserves_once_guard() {
+    // counts the number of times the once() call below is made
+    let once_calls = Arc::new(AtomicU32::new(0));
+
+    // counts the number of times the value returned from once() below is GC'd
+    let once_drops = Arc::new(AtomicU32::new(0));
+
+    let (adder, drop_adder) = (once_calls.clone(), once_drops.clone());
+    let mut rt = RunLoop::new(move || {
+        println!("\n\nrunning loop again");
+        let (commit, key) = moxie::state(|| false);
+
+        // caching with the current revision should be a no-op
+        println!("calling cache");
+        cache(&Revision::current(), |_| {
+            println!("entered cache");
+            if *commit {
+                // this call should be GC'd if commit is false
+                println!("calling once");
+                once(|| {
+                    println!("entered once");
+                    adder.fetch_add(1, Ordering::SeqCst);
+                    Arc::new(CountDrops { num_drops: drop_adder.clone() })
+                });
+            }
+        });
+
+        key
+    });
+
+    // first execution, key is `false` here, no once() call
+    let key = rt.run_once();
+    assert_eq!(once_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(once_drops.load(Ordering::SeqCst), 0);
+
+    // set key to true, once() should execute but not drop
+    key.set(true);
+    rt.run_once();
+    assert_eq!(once_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(once_drops.load(Ordering::SeqCst), 0);
+
+    // set key to false, once() should not execute and should get GC'd
+    key.set(false);
+    rt.run_once();
+    assert_eq!(once_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(once_drops.load(Ordering::SeqCst), 1);
+}

--- a/topo/Cargo.toml
+++ b/topo/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 wasm-bindgen = [ "dyn-cache/wasm-bindgen", "parking_lot/wasm-bindgen" ]
 
 [dependencies]
-dyn-cache = { path = "../dyn-cache", version = "0.12.1"}
+dyn-cache = { path = "../dyn-cache", version = "0.12.2"}
 illicit = { path = "../illicit", version = "1.1.2"}
 once_cell = "1.4.0"
 parking_lot = "0.11.0"


### PR DESCRIPTION
Fixes #238.